### PR TITLE
Add -XX:-UsePerfData to disable creation of hsperfdata_root dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,5 @@ RUN apk add --no-cache tini libc6-compat
 
 COPY --from=build /parquet-mr/parquet-tools/target/parquet-tools-1.9.0.jar /parquet-tools.jar
 
-ENTRYPOINT ["/sbin/tini", "--", "java", "-jar", "/parquet-tools.jar"]
+ENTRYPOINT ["/sbin/tini", "--", "java", "-XX:-UsePerfData", "-jar", "/parquet-tools.jar"]
 


### PR DESCRIPTION
Today, an empty directory `hsperfdata_root` is created by java runtime on each run. This flag disables it